### PR TITLE
Refactor: remove unnecessary allocations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,17 +3,14 @@ use std::process::Command;
 use chrono::prelude::*;
 
 fn main() {
-    let mut version = command("git", vec!["describe", "--tags", "--dirty"])
-        .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION").to_string()));
+    let short_version = command("git", ["describe", "--tags", "--dirty"])
+        .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")));
 
-    let short_version = version.clone();
+    let commit = command("git", ["rev-parse", "--short", "HEAD"]).unwrap_or_default();
 
-    let commit =
-        command("git", vec!["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "".to_string());
+    let timestamp = Utc::now().format("%Y%m%d%H%M%S");
 
-    let timestamp = Utc::now().format("%Y%m%d%H%M%S").to_string();
-
-    version = format!("{} Commit: {}-{}", version, commit, timestamp);
+    let version = format!("{} Commit: {}-{}", short_version, commit, timestamp);
 
     println!("cargo:rustc-env=VERSION={}", short_version);
     println!("cargo:rustc-env=LONG_VERSION={}", version);

--- a/src/cmd/issue/add_label.rs
+++ b/src/cmd/issue/add_label.rs
@@ -54,11 +54,7 @@ impl CommandTrait for AddLabelCommand {
         let config = NoteConfig::new(matches);
         let repo_component = RepoComponent::new(None, Arc::new(config));
         let query = matches.value_of("query").unwrap_or_default();
-        let labels: Vec<_> = matches
-            .values_of("labels")
-            .unwrap()
-            .map(|it| it.to_string())
-            .collect();
+        let labels: Vec<_> = matches.values_of("labels").unwrap().collect();
 
         let issues_to_update = create_issues_info_to_update(
             &repo_component,

--- a/src/cmd/issue/remove_label.rs
+++ b/src/cmd/issue/remove_label.rs
@@ -54,11 +54,7 @@ impl CommandTrait for RemoveLabelCommand {
         let config = NoteConfig::new(matches);
         let repo_component = RepoComponent::new(None, Arc::new(config));
         let query = matches.value_of("query").unwrap_or_default();
-        let labels: Vec<_> = matches
-            .values_of("labels")
-            .unwrap()
-            .map(|it| it.to_string())
-            .collect();
+        let labels: Vec<_> = matches.values_of("labels").unwrap().collect();
 
         let issues_to_update = create_issues_info_to_update(
             &repo_component,

--- a/src/component/note.rs
+++ b/src/component/note.rs
@@ -60,8 +60,13 @@ fn assignees_str(args: &HashMap<String, Value>) -> tera::Result<Value> {
     match args.get("value") {
         Some(val) => match from_value::<Vec<String>>(val.clone()) {
             Ok(assignees) => {
-                let assignees: Vec<_> = assignees.iter().map(|it| format!("@{}", it)).collect();
-                Ok(to_value(assignees.join(" ")).unwrap())
+                use std::fmt::Write;
+                let mut str = String::with_capacity(assignees.len() * 3);
+                for assignee in assignees.iter() {
+                    write!(&mut str, "@{} ", assignee).unwrap();
+                }
+                str.pop();
+                Ok(to_value(str)?)
             }
             Err(_) => Err("".into()),
         },

--- a/src/component/note.rs
+++ b/src/component/note.rs
@@ -157,22 +157,17 @@ impl NoteComponentTrait for NoteComponent {
         let mut issue_sections: Vec<_> = issue_sections.values().collect();
         issue_sections.sort_by(|a, b| a.index.partial_cmp(&b.index).unwrap());
 
-        let assignees: Vec<_> = issues.iter().flat_map(|it| &it.assignees).collect();
-        let mut assignees: Vec<_> = assignees
-            .into_iter()
-            .map(|it| it.login.clone())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
+        let mut assignees = issues
+            .iter()
+            .flat_map(|it| &it.assignees)
+            .map(|x| x.login.as_str())
+            .collect::<HashSet<_>>();
 
-        if let Some(contributors) = self.config.extra_contributors.clone() {
-            for contributor in contributors {
-                if !assignees.contains(&contributor) {
-                    assignees.push(contributor.clone());
-                }
-            }
+        if let Some(contributors) = &self.config.extra_contributors {
+            assignees.extend(contributors.iter().map(|s| s.as_str()));
         }
 
+        let mut assignees: Vec<_> = assignees.into_iter().collect();
         assignees.sort();
 
         let mut tera = Tera::default();


### PR DESCRIPTION
Some minor performance improvement, mainly removing unnecessary memory allocation, such like `.clone()`, `.collect()`, `.to_string()`, or `format!`.

I didn't test the functionality but it shouldn't mess up things, since I only take cakes of code level but not business level.